### PR TITLE
Fix faulty YAML indent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ services:
       LIMESURVEY_ADMIN_PASSWORD: password
       LIMESURVEY_ADMIN_NAME: Lime Administrator
       LIMESURVEY_ADMIN_EMAIL: lime@lime.lime
-   volumes:
+    volumes:
       - ./plugins:/var/www/html/plugins
       - ./upload:/var/www/html/upload
       - ./config:/var/www/html/application/config


### PR DESCRIPTION
There is a missing space causing docker compose to throw this error: `yaml: line 14: did not find expected key`